### PR TITLE
Support Rails 3.2

### DIFF
--- a/active_model-errors_details.gemspec
+++ b/active_model-errors_details.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", ">= 4.0", "< 5.0.0.alpha"
+  spec.add_dependency "activemodel", ">= 3.2", "< 5.0.0.alpha"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "minitest", "~> 5.6"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/active_model/errors_details.rb
+++ b/lib/active_model/errors_details.rb
@@ -1,6 +1,31 @@
 require "active_model/errors_details/version"
 require "active_model/errors"
-require "active_support/core_ext/object/deep_dup"
+
+begin
+  require "active_support/core_ext/object/deep_dup"
+rescue LoadError
+  require "active_support/core_ext/object/duplicable"
+
+  class Object
+    def deep_dup
+      duplicable? ? dup : self
+    end
+  end
+
+  class Array
+    def deep_dup
+      map(&:deep_dup)
+    end
+  end
+
+  class Hash
+    def deep_dup
+      each_with_object(dup) do |(key, value), hash|
+        hash[key.deep_dup] = value.deep_dup
+      end
+    end
+  end
+end
 
 module ActiveModel
   module ErrorsDetails


### PR DESCRIPTION
The only thing this library uses from Rails 4 is the new `Object#deep_dup` behavior. This pull request backports that behavior to support Rails 3.2. 
