### PR TITLE
Ensure that instances of `ActiveModel::Errors` can be marshalled

### DIFF
--- a/lib/active_model/errors_details.rb
+++ b/lib/active_model/errors_details.rb
@@ -117,6 +117,29 @@ module ActiveModel
       details[attribute.to_sym] << error
       add_without_details(attribute, message, options)
     end
+
+    def marshal_dump
+      [@base, without_default_proc(@messages), without_default_proc(@details)]
+    end
+
+    def marshal_load(array)
+      @base, @messages, @details = array
+      apply_default_array(@messages)
+      apply_default_array(@details)
+    end
+
+    private
+
+    def without_default_proc(hash)
+      hash.dup.tap do |new_h|
+        new_h.default_proc = nil
+      end
+    end
+
+    def apply_default_array(hash)
+      hash.default_proc = proc { |h, key| h[key] = [] }
+      hash
+    end
   end
 end
 

--- a/test/test_errors_details.rb
+++ b/test/test_errors_details.rb
@@ -89,4 +89,13 @@ class TestErrorsDetails < MiniTest::Test
 
     assert_empty person.errors.details
   end
+
+  def test_errors_are_marshalable
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    serialized = Marshal.load(Marshal.dump(errors))
+
+    assert_equal errors.messages, serialized.messages
+    assert_equal errors.details, serialized.details
+  end
 end


### PR DESCRIPTION
This is a fix that Sean Griffin (@sgrif) made to Rails master with this commit https://github.com/rails/rails/commit/b3dfd7d16cc37dcaf4298fe42e69a56ab3c6b00e

Fixes issue #7 
